### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+Write a sentence or two here describing what this PR includes along with any additional information that could help reviewers.
+
+If this PR adds a new page of documentation, be sure to edit the `README.md` file to include a link so that it can be found.
+
+If this PR fixes an [issue](https://github.com/openshift/openshift-origin-design/issues), include a [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close that issue once this pull request is merged. Example: `Closes #123`
+
+Remove any of these team mentions to prevent them from being notified:
+@openshift/team-ux-leads, @openshift/team-ux-review, @openshift/team-kni-ux

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,13 @@
 Write a sentence or two here describing what this PR includes along with any additional information that could help reviewers.
 
-If this PR adds a new page of documentation, be sure to edit the `README.md` file to include a link so that it can be found.
+If this PR adds a new page of documentation, be sure to edit the `README.md` file to include a link so that it can be found more easily.
 
 If this PR fixes an [issue](https://github.com/openshift/openshift-origin-design/issues), include a [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close that issue once this pull request is merged. Example: `Closes #123`
 
-Remove any of these team mentions to prevent them from being notified:
-@openshift/team-ux-leads, @openshift/team-ux-review, @openshift/team-kni-ux
+@openshift/team-ux-leads
+
+Optional team mentions (include any are related to this PR):
+
+@openshift/team-ux-review (Core UX team)
+@openshift/team-devconsole-ux (Dev Console UX team)
+@openshift/team-kni-ux (KNI & KubeVirt UX team)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,6 @@ If this PR fixes an [issue](https://github.com/openshift/openshift-origin-design
 
 Optional team mentions (include any are related to this PR):
 
-@openshift/team-ux-review (Core UX team)
+@openshift/team-ux-review (Admin Console UX team)
 @openshift/team-devconsole-ux (Dev Console UX team)
 @openshift/team-kni-ux (KNI & KubeVirt UX team)


### PR DESCRIPTION
GitHub’s [pull request template](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository) feature allows us to pre-fill the description field of new PRs.

This could be a helpful way to remind ourselves to mention any issues a PR closes, tag the relevant teams that should review the PR, and edit the `README.md` if needed.

The phrasing in here is just a first draft and totally up to tweak. Let me know what you think!

@openshift/team-ux-review @openshift/team-kni-ux