### PR TITLE
adding link to vm-templates PR on the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Access design documentation specific to the KNI and KubeVirt features in OpenShi
 - Clone VM
 - Migrate VM
 - [VM List](http://openshift.github.io/openshift-origin-design/web-console/knikubevirt/vm-list/vm-list)
+- [VM Templates](http://openshift.github.io/openshift-origin-design/web-console/knikubevirt/vm-templates/vm-templates)
 - VM Details
 - VM Console
 


### PR DESCRIPTION
I didn't add a link to the README.md file for [#173]https://github.com/openshift/openshift-origin-design/pull/173). So adding it now.
I'm using the same branch name "vm-template"