### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Access design documentation for features slotted in the 4.2 release of OpenShift
 - [Taints and Tolerations](http://openshift.github.io/openshift-origin-design/web-console/future-openshift/taints-tolerations/taints-tolerations)
 
 ## OpenShift Container Storage
-- [OCS Install workflow](./web-console/Storage/OCS/OCS%20_Installation_Workflow.md)
-- [OB & OBC-Lifecycle-Management](./web-console/Storage/OB-OB-Lifecycle-Management/OB-OBC-Lifecycle.md)
+- [OCS Install workflow](./web-console/Storage/OCS/OCS%20_Installation_Workflow)
+- [OB & OBC-Lifecycle-Management](./web-console/Storage/OB-OB-Lifecycle-Management/OB-OBC-Lifecycle)
 
 ### KNI and KubeVirt Designs
 [Access design documentation specific to the KNI and Kubevirt features in the OpenShift Console.](http://openshift.github.io/openshift-origin-design/web-console/knikubevirt/knikubevirt)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Access design documentation for features slotted in the 4.2 release of OpenShift
 - [Taints and Tolerations](http://openshift.github.io/openshift-origin-design/web-console/future-openshift/taints-tolerations/taints-tolerations)
 
 ## OpenShift Container Storage
-- [OCS Install workflow](./web-console/Storage/OCS/OCS_Installation_Workflow.md)
-- [OB-OB-Lifecycle-Management ](./web-console/Storage/OB-OB-Lifecycle-Management/OB-OBC-Lifecycle.md)
+- [OCS Install workflow](./web-console/Storage/OCS/OCS%20_Installation_Workflow.md)
+- [OB & OBC-Lifecycle-Management](./web-console/Storage/OB-OB-Lifecycle-Management/OB-OBC-Lifecycle.md)
 
 ### KNI and KubeVirt Designs
 [Access design documentation specific to the KNI and Kubevirt features in the OpenShift Console.](http://openshift.github.io/openshift-origin-design/web-console/knikubevirt/knikubevirt)


### PR DESCRIPTION
fixed a dead link and typo in the OpenShift Container Storage section
- OCS Install workflow -- changed the URL as the link was not going to the right place (dead link)
- OB & OBC-Lifecycle-Management -- typo should be OB & OBC (and not OB-OB)

@openshift/team-ux-leads
@shirimordechay 