### PR TITLE
Fix new site assets not loading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: OpenShift Design
+url: "https://openshift.github.io"
 baseurl: "/openshift-origin-design/"
 # permalink: /:title
 remote_theme: "pmarsceill/just-the-docs@v0.2.7"


### PR DESCRIPTION
Should fix the new site being broken by specifying the site's `url` in the config with `https` defined, which should enforce `https` for the assets as well to avoid mixed content errors.