### PR TITLE
Site: Fix version page ordering and embiggen search icon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -143,20 +143,25 @@ layout: table_wrappers
             </ul>
           {% endif %}
           {% endfor %}
-
+          
           <!-- Designs by category -->
           {% if page.version_page == true %}
-            {% assign children_list = site.pages | where: "version", page.version | where_exp: "item","item.title != page.title" | group_by: 'parent' | sort:"title" | reverse %}
-            {% for par in children_list %}
-            <h2>{{ par.name }}</h2>
+            {% assign parent_list = site.pages | where: "parent", "Designs" | sort: "title" %}
+            {% for parent in parent_list %}
+              <h2>{{ parent.title }}</h2>
+              {% assign children_list = site.pages | where: "version", page.version | where: "parent", parent.title | where_exp: "item","item.title != page.title" | sort:"title" %}
+              {% assign children_size = site.pages | where: "version", page.version | where: "parent", parent.title | where_exp: "item","item.title != page.title" | size %}
+              {% if children_size != 0 %}
                 <ul>
-                  {% assign items = par.items | sort: 'title' %}
-                  {% for item in items %}
-                    <li>
-                      <a href="{{ item.url | absolute_url }}">{{ item.title }}</a>{% if child.summary %} - {{ child.summary }}{% endif %}
-                    </li>
-                  {% endfor %}
+                {% for child in children_list %}
+                  <li>
+                    <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>{% if child.summary %} - {{ child.summary }}{% endif %}
+                  </li>
+                {% endfor %}
                 </ul>
+              {% else %}
+                <p>None</p>
+              {% endif %}
             {% endfor %}
           {% endif %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -148,20 +148,22 @@ layout: table_wrappers
           {% if page.version_page == true %}
             {% assign parent_list = site.pages | where: "parent", "Designs" | sort: "title" %}
             {% for parent in parent_list %}
-              <h2>{{ parent.title }}</h2>
-              {% assign children_list = site.pages | where: "version", page.version | where: "parent", parent.title | where_exp: "item","item.title != page.title" | sort:"title" %}
-              {% assign children_size = site.pages | where: "version", page.version | where: "parent", parent.title | where_exp: "item","item.title != page.title" | size %}
-              {% if children_size != 0 %}
-                <ul>
-                {% for child in children_list %}
-                  <li>
-                    <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>{% if child.summary %} - {{ child.summary }}{% endif %}
-                  </li>
-                {% endfor %}
-                </ul>
-              {% else %}
-                <p>None</p>
-              {% endif %}
+              {% unless parent.title == "Concepts" %}
+                <h2>{{ parent.title }}</h2>
+                {% assign children_list = site.pages | where: "version", page.version | where: "parent", parent.title | where_exp: "item","item.title != page.title" | sort:"title" %}
+                {% assign children_size = site.pages | where: "version", page.version | where: "parent", parent.title | where_exp: "item","item.title != page.title" | size %}
+                {% if children_size != 0 %}
+                  <ul>
+                  {% for child in children_list %}
+                    <li>
+                      <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>{% if child.summary %} - {{ child.summary }}{% endif %}
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% else %}
+                  <p>None</p>
+                {% endif %}
+              {% endunless %}
             {% endfor %}
           {% endif %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,7 +161,7 @@ layout: table_wrappers
                   {% endfor %}
                   </ul>
                 {% else %}
-                  <p>None</p>
+                  <p>No designs</p>
                 {% endif %}
               {% endunless %}
             {% endfor %}

--- a/_sass/overrides.scss
+++ b/_sass/overrides.scss
@@ -178,3 +178,8 @@ figure > a:hover {
 .navigation-list-child-list .navigation-list-item::before {
   content: none;
 }
+
+.search-icon {
+  width: auto;
+  height: 18px;
+}


### PR DESCRIPTION
The order of some release pages was wacky and the teensy search icon was a little too easy to miss.

For technical reasons it's easiest if all sections are shown even when they don't include any designs for a given release. In motion it feels pretty normal though (more consistent anchors).

![version-order-search](https://user-images.githubusercontent.com/9122899/74623656-7f49e880-5113-11ea-9ff7-00b0360b5eaa.png)

@openshift/team-ux-leads