### PR TITLE
PR template tweaks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
-Write a sentence or two describing what this PR includes along with any additional information that could be helpful to reviewers.
+<!-- Write a sentence or two below describing what this PR includes along with any additional information that could be helpful to reviewers. -->
 
-Check to make sure the top of your PR has the correct Parent (Administrator, Developer, etc.) and Version (4.0, 4.x, etc.). If this design is a conceptual design with no clear release date, the parent should be "Concepts".
+Description here.
 
-If this PR fixes an [issue](https://github.com/openshift/openshift-origin-design/issues), include a [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close that issue once this pull request is merged. Example: `Closes #123`
+<!-- The top of each Markdown file should include a Parent (Administrator, Developer, etc.) and Version (4.0, 4.x, etc.). When possible, name Markdown files index.md for cleaner URLs.  -->
 
+<!-- Required team mentions: -->
 @openshift/team-ux-leads
 
-Optional team mentions (include any that are related to this PR):
-
-@openshift/team-ux-review (Admin Console UX team)
-@openshift/team-devconsole-ux (Dev Console UX team)
-@openshift/team-kni-ux (KNI & KubeVirt UX team)
+<!-- Optional team mentions (include any that are related to this PR): -->
+@openshift/team-ux-review (Administrator perspective)
+@openshift/team-devconsole-ux (Developer perspective)
+@openshift/team-kni-ux (KNI & Virtualization)


### PR DESCRIPTION
Places instructional text within `<!-- comment blocks -->` that aren't visible when published, so they don't need to be manually deleted anymore. Also slightly tweaks the instructions about Parent/Version, updates "CNV" to "Virtualization", and clarifies that mentioning the team-ux-leads team is required.

PR creators would see this:
```
<!-- Write a sentence or two below describing what this PR includes along with any additional information that could be helpful to reviewers. -->

Description here.

<!-- The top of each Markdown file should include a Parent (Administrator, Developer, etc.) and Version (4.0, 4.x, etc.). When possible, name Markdown files index.md for cleaner URLs.  -->

<!-- Required team mentions: -->
@openshift/team-ux-leads

<!-- Optional team mentions (include any that are related to this PR): -->
@openshift/team-ux-review (Administrator perspective)
@openshift/team-devconsole-ux (Developer perspective)
@openshift/team-kni-ux (KNI & Virtualization)
```

@openshift/team-ux-leads