### PR TITLE
Site: fix certain images appearing in the wrong order

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -72,11 +72,11 @@ function insertResults(results) {
   }
 }
 
-transformImages();
 function transformImages() {
 
   // Move all images up out of P's
   var elements = document.querySelectorAll('#main-content img');
+  var elements = [].slice.call(elements, 0).reverse(); // Start from the bottom of the array to handle images within the same p
   for (var i = 0; i < elements.length; i++) {
 
     // console.log("Processing:" + elements.length);


### PR DESCRIPTION
<!-- Write a sentence or two below describing what this PR includes along with any additional information that could be helpful to reviewers. -->

Fixes a bug that would reverse the order of images placed directly next to one another in a Markdown file with no physical distancing, like this example from the [Creating page](http://openshift.github.io/openshift-origin-design/conventions/documentation/create.html):

```
![Click create](../images/image-1.png)
![YAML editor](../images/image-2.png)
```

![image](https://user-images.githubusercontent.com/9122899/79672567-4a085800-81a1-11ea-8fb8-c5a4fba649c2.png)

This made reading through some flows pretty challenging. Thank you for pointing this out @itsptk!

🤓 Geek notes: The `transformImages` function (necessary for the image embiggenifier to work) would pull images out of `p` elements starting from the first image of the design down to the last. When two images are directly adjacent in a Markdown file they're placed within one `p`, so the first image would get pulled out before the second image would, reversing their original order. The one-liner solution here just flips the order in which images are processed from bottom-to-top, fixing that problem.

<!-- Required team mentions: -->
@openshift/team-ux-leads