### PR TITLE
Updated Tech Preview Badge Convention

### DIFF
--- a/conventions/documentation/badges.md
+++ b/conventions/documentation/badges.md
@@ -65,7 +65,7 @@ To view status badges in the [OpenShift Sketch Library](https://sketch.cloud/s/m
 
 ## Tech preview badge
 
-A tech preview badge indicates when a feature is new and may still be in-progress on the development side. This can be Dev or Tech preview, and the same color is utilized for both. To view the tech preview badge in the [OpenShift Sketch Library](https://sketch.cloud/s/mwdww) visit the symbols page [here](https://sketch.cloud/s/mwdww/p/symbols).
+A tech preview badge indicates when a feature is new and may still be in-progress on the development side. This can be Dev or Tech preview, and the same color is utilized for both. Tech preview badges should appear to the right of the label. To view the tech preview badge in the [OpenShift Sketch Library](https://sketch.cloud/s/mwdww) visit the symbols page [here](https://sketch.cloud/s/mwdww/p/symbols).
 
 
 *Example of tech preview badge on feature*

--- a/conventions/documentation/toolbars.md
+++ b/conventions/documentation/toolbars.md
@@ -1,3 +1,0 @@
----
-parent: Conventions
----

--- a/conventions/documentation/toolbars.md
+++ b/conventions/documentation/toolbars.md
@@ -1,0 +1,3 @@
+---
+parent: Conventions
+---


### PR DESCRIPTION
Added a short sentence to the existing tech preview badge convention that states that tech preview badges should appear to the right of the label.

Closes [#439](https://github.com/openshift/openshift-origin-design/issues/439)

@openshift/team-ux-leads
@openshift/team-ux-review (Administrator perspective)
@openshift/team-devconsole-ux (Developer perspective)
@openshift/team-kni-ux (KNI & Virtualization)
@gdoyle1 