### PR TITLE
Add competitive navigation research page

### DIFF
--- a/research/competitive_navigation/index.md
+++ b/research/competitive_navigation/index.md
@@ -1,0 +1,11 @@
+---
+parent: Research
+
+---
+# Competitive Navigation
+
+*Date: August 2020*
+
+*Internal link: [Slide deck](https://docs.google.com/presentation/d/1Bc7WFpiUMCF-1eeimcwkQZ9bZOhq2BWzZPg-E39TsFc/edit#slide=id.p)*
+
+This research project is currently only able to be viewed by Red Hat employees.


### PR DESCRIPTION
Adds a link to @LPutney's research on competitive navigation to the Research section of the site.

@openshift/team-ux-leads @carljpearson