### PR TITLE
Developer page clean up and a couple more edits 

### DIFF
--- a/conventions/index.md
+++ b/conventions/index.md
@@ -1,7 +1,7 @@
 ---
 nav_label: Conventions
 has_children: true
-nav_order: 4
+nav_order: 1
 ---
 
 # Conventions

--- a/designs/developer/index.md
+++ b/designs/developer/index.md
@@ -1,33 +1,3 @@
----
-parent: Designs
-include_designs_by_version: false
----
-
-# Developer
-
-## Overview
-The Developer Perspective, added to the 4.2 OpenShift Console, provides developers with an optimized experience with the features and workflows they’re most likely to need to be productive. Developers can focus on higher level abstractions like their application and components, and then drill down deeper to get to the OpenShift and Kubernetes resources that make up their application.
-
-We strive for simplicity, while still allowing for users to achieve more advanced flows.  We focus on efficiency for those workflows that are more frequently utilized.
-
-Our design documentation covers the entire developer experience in the OpenShift Console.  The developer experience is enhanced as operators are installed, which is also documented below.
-
-## Main Use Cases 
-The main use cases of the Developer Perspective include: 
-- Utilizing the topology view to view resources 
-- Adding resources to your topology 
-- Monitoring your resources
-- Modifying your resources 
-- Enchancing the Developer Perspective with operators 
-
-## Personas
-Here we could include brief information about the sorts of personas who are the main users of the developer perspective. 
-
-Some of the main users who utilize the Developer Perspective include: 
-- Developers  
-- User type 
-- User type
-
 # Releases 
 
 4.x

--- a/overview/developer/index.md
+++ b/overview/developer/index.md
@@ -1,0 +1,30 @@
+---
+nav_label: Overview
+has_children: true
+nav_order: 3
+---
+
+# Developer
+
+## Overview
+The Developer Perspective, added to the 4.2 OpenShift Console, provides developers with an optimized experience with the features and workflows they’re most likely to need to be productive. Developers can focus on higher level abstractions like their application and components, and then drill down deeper to get to the OpenShift and Kubernetes resources that make up their application.
+
+We strive for simplicity, while still allowing for users to achieve more advanced flows.  We focus on efficiency for those workflows that are more frequently utilized.
+
+Our design documentation covers the entire developer experience in the OpenShift Console.  The developer experience is enhanced as operators are installed, which is also documented below.
+
+## Main Use Cases 
+The main use cases of the Developer Perspective include: 
+- Utilizing the topology view to view resources 
+- Adding resources to your topology 
+- Monitoring your resources
+- Modifying your resources 
+- Enchancing the Developer Perspective with operators 
+
+## Personas
+Here we could include brief information about the sorts of personas who are the main users of the developer perspective. 
+
+Some of the main users who utilize the Developer Perspective include: 
+- Developers  
+- User type 
+- User type

--- a/overview/index.md
+++ b/overview/index.md
@@ -1,0 +1,45 @@
+---
+nav_label: Overview
+has_children: true
+nav_order: 3
+---
+
+# Developer
+
+## Overview
+The Developer Perspective, added to the 4.2 OpenShift Console, provides developers with an optimized experience with the features and workflows they’re most likely to need to be productive.
+
+## Main Use Cases 
+The main use cases of the Developer Perspective include: 
+- Utilizing the topology view to view resources 
+- Adding resources to your topology 
+- Monitoring your resources
+- Modifying your resources 
+- Enchancing the Developer Perspective with operators 
+
+## Personas
+
+Developers are one of the main types of users who might utilize the Developer Perspective. Some of the developer persona types we are designing for include the following.
+
+### OpenShift Explorer 
+
+The OpenShift Explorer is discovering and learning about OpenShift or new features in OpenShift, such as Pipelines or Serverless. The OpenShift Explorer expects efficient and intuitive workflows.
+
+### Code Locator
+
+The Code Locator brings up an IDE with the code associated with a service in OpenShift. The Code Locator does not spend a lot of time in the OpenShift console since they need to locate the associated code.
+
+### Application Builder
+
+The Application Builder wants to quickly assemble an application and spends most of their time in the IDE. The Application Builder wants to go into OpenShift and be able to quickly build and deploy an application.
+
+### Application Deployer
+
+The Application Deployer deploys applications to OpenShift from their IDE. The Application Deployer spends most of their time in the IDE but wants to view the status of builds, pipelines, and applications.  
+
+### Application Monitor
+
+I monitor the health of applications and their components.
+I expect to be able to view the application topology and be able to easily understand the health status of the application as well as it’s components, so that i can identify areas to troubleshoot.
+
+

--- a/releases/index.md
+++ b/releases/index.md
@@ -1,6 +1,6 @@
 ---
 has_children: true
-nav_order: 3
+nav_order: 4
 ---
 
 # Releases

--- a/research/index.md
+++ b/research/index.md
@@ -1,6 +1,6 @@
 ---
 has_children: true
-nav_order: 4
+nav_order: 5
 ---
 
 # Research


### PR DESCRIPTION
Cleaned up the developer page so it features just the release info, similar to the administrator page. I also updated the nav order so the nav items are now in alphabetical order. I also added an overview section to the nav items so you can find overview, persona, and use case information for each perspective.

@openshift/team-ux-leads
@openshift/team-devconsole-ux 
