### PR TITLE
Fix typo

### DIFF
--- a/designs/administrator/future-openshift/cluster-setup/index.md
+++ b/designs/administrator/future-openshift/cluster-setup/index.md
@@ -1,6 +1,6 @@
 ---
 parent: Administrator
-version: 4.X
+version: 4.x
 ---
 
 # Cluster Setup


### PR DESCRIPTION
Fixes a typo that placed Cluster Setup in the wrong release version